### PR TITLE
feat(hubspot): allow oncehub_user_id in track validation

### DIFF
--- a/src/v0/destinations/hs/HSTransform-v2.ts
+++ b/src/v0/destinations/hs/HSTransform-v2.ts
@@ -288,10 +288,14 @@ const processTrack = async ({
     ...constructPayload(message, mappingConfig[ConfigCategory.TRACK_PROPERTIES.name]),
   };
 
-  // either of email or utk or objectId (Could be a 'contact id' or a 'visitor id') should be present
-  if (!payload.email && !payload.utk && !payload.objectId) {
+  // either of email or utk or objectId (Could be a 'contact id' or a 'visitor id') or oncehub_user_id should be present
+  // https://github.com/rudderlabs/rudder-transformer/issues/5058
+  const hasDefaultIdentifier = Boolean(payload.email || payload.utk || payload.objectId);
+  const hasCustomIdentifier = Boolean(payload.properties?.oncehub_user_id);
+
+  if (!hasDefaultIdentifier && !hasCustomIdentifier) {
     throw new InstrumentationError(
-      'Either of email, utk or objectId is required for custom behavioral events',
+      'Either of email, utk, objectId, or oncehub_user_id is required for custom behavioral events',
     );
   }
 


### PR DESCRIPTION
https://scheduleonce.atlassian.net/browse/ONCEHUB-112766

feat(hubspot): allow oncehub_user_id in track validation

Summary
- Updates HubSpot v3 track validation to accept properties.oncehub_user_id as an alternative identifier when email/utk/objectId are missing.
- Updates validation error text accordingly.

Scope
- Only changes src/v0/destinations/hs/HSTransform-v2.ts.
- Does not include accountId -> oncehub_account_id normalization in destination code.

Notes
- Account/user normalization is handled via destination cloud transform configuration.
- This is aligned with upstream blocker: https://github.com/rudderlabs/rudder-transformer/issues/5058
